### PR TITLE
Some model corrections and more robust convergences for all architectures

### DIFF
--- a/src/fastuav/configurations/fixedwing_mdo.yaml
+++ b/src/fastuav/configurations/fixedwing_mdo.yaml
@@ -12,6 +12,10 @@ driver: om.ScipyOptimizeDriver(tol=1e-9, optimizer='SLSQP')
 
 # Definition of OpenMDAO model
 model:
+    # Converge the discipline coupling at every evaluation so the design point is self-consistent
+    # and the (analytic) total derivatives are exact for the optimizer.
+    nonlinear_solver: om.NonlinearBlockGS(maxiter=200, atol=1.0e-9, rtol=1.0e-9, iprint=0)
+    linear_solver: om.DirectSolver()
     scenarios:
         id: fastuav.scenarios.fixedwing
     propulsion:

--- a/src/fastuav/configurations/hybrid_mdo.yaml
+++ b/src/fastuav/configurations/hybrid_mdo.yaml
@@ -12,6 +12,10 @@ driver: om.ScipyOptimizeDriver(tol=1e-9, optimizer='SLSQP')
 
 # Definition of OpenMDAO model
 model:
+    # Converge the discipline coupling at every evaluation so the design point is self-consistent
+    # and the (analytic) total derivatives are exact for the optimizer.
+    nonlinear_solver: om.NonlinearBlockGS(maxiter=300, atol=1.0e-9, rtol=1.0e-9, iprint=0)
+    linear_solver: om.DirectSolver()
     scenarios:
         id: fastuav.scenarios.hybrid
     propulsion:

--- a/src/fastuav/configurations/multirotor_mdo.yaml
+++ b/src/fastuav/configurations/multirotor_mdo.yaml
@@ -12,6 +12,10 @@ driver: om.ScipyOptimizeDriver(tol=1e-9, optimizer='SLSQP')
 
 # Definition of OpenMDAO model
 model:
+    # Converge the discipline coupling at every evaluation so the design point is self-consistent
+    # and the (analytic) total derivatives are exact for the optimizer.
+    nonlinear_solver: om.NonlinearBlockGS(maxiter=200, atol=1.0e-9, rtol=1.0e-9, iprint=0)
+    linear_solver: om.DirectSolver()
     scenarios:
         id: fastuav.scenarios.multirotor
     propulsion:

--- a/src/fastuav/models/aerodynamics/aerodynamics_fixedwing.py
+++ b/src/fastuav/models/aerodynamics/aerodynamics_fixedwing.py
@@ -272,7 +272,7 @@ class ParasiticDragConstraint(om.ExplicitComponent):
     """
 
     def setup(self):
-        self.add_input("optimization:variables:aerodynamics:CD0:guess", val=0.04, units=None)
+        self.add_input("optimization:variables:aerodynamics:CD0:guess", val=np.nan, units=None)
         self.add_input("data:aerodynamics:CD0", val=np.nan, units=None)
         self.add_output("optimization:constraints:aerodynamics:CD0:consistency", units=None)
 

--- a/src/fastuav/models/geometry/geometry_fixedwing.py
+++ b/src/fastuav/models/geometry/geometry_fixedwing.py
@@ -320,7 +320,9 @@ class FuselageGeometry(om.ExplicitComponent):
         self.add_output("data:geometry:fuselage:surface:nose", units="m**2", lower=0.0)
         self.add_output("data:geometry:fuselage:surface:mid", units="m**2", lower=0.0)
         self.add_output("data:geometry:fuselage:surface:rear", units="m**2", lower=0.0)
+        self.add_output("data:geometry:fuselage:volume:nose", units="m**3", lower=0.0)
         self.add_output("data:geometry:fuselage:volume:mid", units="m**3", lower=0.0)
+        self.add_output("data:geometry:fuselage:volume:rear", units="m**3", lower=0.0)
 
     def setup_partials(self):
         # Finite difference all partials.
@@ -349,7 +351,16 @@ class FuselageGeometry(om.ExplicitComponent):
         S_nose = 2 * np.pi * (d_fus_mid / 2) ** 2  # nose part of fuselage (half spherical) [m2]
         S_fus = S_rear + S_mid + S_nose  # total fuselage area [m2]
 
+        V_nose = (
+            np.pi * (4 / 6) * l_nose * (0.5 * d_fus_mid) ** 2
+        )  # nose part of fuselage (half ellipsoid) [m3]
         V_mid = np.pi * (d_fus_mid / 2) ** 2 * l_mid  # mid part of fuselage (cylindrical) [m3]
+        V_rear = (
+            np.pi
+            * l_rear
+            * ((0.5 * d_fus_mid) ** 2 + (0.5 * d_fus_tip) ** 2 + 0.25 * d_fus_mid * d_fus_tip)
+            / 3
+        )  # rear part of fuselage (truncated cone) [m3]
 
         outputs["data:geometry:fuselage:length"] = l_fus
         outputs["data:geometry:fuselage:length:nose"] = l_nose
@@ -361,7 +372,9 @@ class FuselageGeometry(om.ExplicitComponent):
         outputs["data:geometry:fuselage:surface:nose"] = S_nose
         outputs["data:geometry:fuselage:surface:mid"] = S_mid
         outputs["data:geometry:fuselage:surface:rear"] = S_rear
+        outputs["data:geometry:fuselage:volume:nose"] = V_nose
         outputs["data:geometry:fuselage:volume:mid"] = V_mid
+        outputs["data:geometry:fuselage:volume:rear"] = V_rear
 
 
 class ProjectedAreasGuess(om.ExplicitComponent):

--- a/src/fastuav/models/propulsion/motor/performance_analysis.py
+++ b/src/fastuav/models/propulsion/motor/performance_analysis.py
@@ -365,7 +365,7 @@ class MotorEfficiency(om.ExplicitComponent):
 
         partials[
             "data:propulsion:motor:efficiency:%s" % scenario,
-            "data:propulsion:motor:voltage:%s" % scenario,
+            "data:propulsion:motor:current:%s" % scenario,
         ] = -T_mot * W_mot / (U_mot * I_mot**2)
 
         partials[

--- a/src/fastuav/models/propulsion/propeller/performance_analysis.py
+++ b/src/fastuav/models/propulsion/propeller/performance_analysis.py
@@ -46,7 +46,9 @@ class PropellerPerformanceModel:
                 (V_inf * np.cos(alpha)) ** 2 + (V_inf * np.sin(alpha) + x) ** 2
             ) ** (1 / 2)
 
-        v_i = fsolve(func, x0=1)[0]
+        # Tight tolerance: the result is finite-differenced upstream, so the solver
+        # residual must be well below the FD step to avoid noisy/inconsistent gradients.
+        v_i = fsolve(func, x0=1, xtol=1e-12)[0]
         return v_i
 
     @staticmethod
@@ -56,9 +58,13 @@ class PropellerPerformanceModel:
         Valid in any condition (hover and forward flight).
         """
         v_i = PropellerPerformanceModel.induced_velocity(F_pro, D_pro, V_inf, alpha, rho_air)
-        try:
-            eta = (V_inf * np.sin(alpha) + v_i) / (W_pro / (2 * np.pi) * D_pro) * c_t / c_p
-        except (ZeroDivisionError, ValueError):
+        denom = (W_pro / (2 * np.pi)) * D_pro
+        # Guard against a stopped propeller (e.g. VTOL rotors in cruise): W_pro -> 0
+        # would otherwise yield a NaN efficiency (numpy division by zero is not caught
+        # by ZeroDivisionError).
+        if denom > 1e-12 and c_p > 1e-12:
+            eta = (V_inf * np.sin(alpha) + v_i) / denom * c_t / c_p
+        else:
             eta = 0.0
         return eta
 

--- a/src/fastuav/models/stability/static_longitudinal/center_of_gravity/cog.py
+++ b/src/fastuav/models/stability/static_longitudinal/center_of_gravity/cog.py
@@ -9,6 +9,10 @@ from fastuav.constants import FW_PROPULSION, MR_PROPULSION, PROPULSION_ID_LIST
 from fastuav.models.stability.static_longitudinal.center_of_gravity.components.cog_airframe import (
     CoG_airframe,
 )
+from fastuav.models.stability.static_longitudinal.center_of_gravity.components.cog_load import (
+    CoG_load_FW,
+    CoG_load_MR,
+)
 from fastuav.models.stability.static_longitudinal.center_of_gravity.components.cog_propulsion import (
     CoG_propulsion_FW,
     CoG_propulsion_MR,
@@ -38,8 +42,10 @@ class CenterOfGravity(om.Group):
 
         if FW_PROPULSION in propulsion_id_list:
             self.add_subsystem("propulsion_fw", CoG_propulsion_FW(), promotes=["*"])
+            self.add_subsystem("load_fw", CoG_load_FW(), promotes=["*"])
         if MR_PROPULSION in propulsion_id_list:
             self.add_subsystem("propulsion_mr", CoG_propulsion_MR(), promotes=["*"])
+            self.add_subsystem("load_mr", CoG_load_MR(), promotes=["*"])
 
         self.add_subsystem("UAV", CoG_UAV(propulsion_id_list=propulsion_id_list), promotes=["*"])
 
@@ -71,8 +77,12 @@ class CoG_UAV(om.ExplicitComponent):
                 units="m",
             )
             self.add_input("data:weight:propulsion:%s" % propulsion_id, val=np.nan, units="kg")
+            self.add_input("data:weight:load:%s" % propulsion_id, val=0.0, units="kg")
+            self.add_input("data:stability:CoG:load:%s" % propulsion_id, val=0.0, units="m")
 
-        self.add_output("data:stability:CoG", units="m")
+        self.add_output("data:stability:CoG:x", units="m")
+        self.add_output("data:stability:CoG:y", units="m")
+        self.add_output("data:stability:CoG:z", units="m")
 
     def setup_partials(self):
         # Finite difference all partials.
@@ -99,9 +109,24 @@ class CoG_UAV(om.ExplicitComponent):
             / m_propulsion
         )
 
-        # UAV
-        x_cg_uav = (x_cg_airframe * m_airframe + x_cg_propulsion * m_propulsion) / (
-            m_propulsion + m_airframe
+        # Load (payload and non-modeled parts)
+        m_load = sum(
+            inputs["data:weight:load:%s" % propulsion_id] for propulsion_id in propulsion_id_list
+        )
+        x_cg_load = (
+            sum(
+                inputs["data:stability:CoG:load:%s" % propulsion_id]
+                * inputs["data:weight:load:%s" % propulsion_id]
+                for propulsion_id in propulsion_id_list
+            )
+            / m_load
         )
 
-        outputs["data:stability:CoG"] = x_cg_uav
+        # UAV
+        x_cg_uav = (
+            x_cg_airframe * m_airframe + x_cg_propulsion * m_propulsion + x_cg_load * m_load
+        ) / (m_propulsion + m_airframe + m_load)
+
+        outputs["data:stability:CoG:x"] = x_cg_uav
+        outputs["data:stability:CoG:y"] = 0
+        outputs["data:stability:CoG:z"] = 0

--- a/src/fastuav/models/stability/static_longitudinal/center_of_gravity/components/cog_airframe.py
+++ b/src/fastuav/models/stability/static_longitudinal/center_of_gravity/components/cog_airframe.py
@@ -134,7 +134,10 @@ class CoG_fuselage(om.ExplicitComponent):
         m_mid = inputs["data:weight:airframe:fuselage:mass:mid"]
         m_rear = inputs["data:weight:airframe:fuselage:mass:rear"]
 
-        x_cg_nose = l_nose * (3 / 4)  # [m] centroid of a half-ellipsoid (nose)
+        # Nose CG, measured from the tip (x=0). The nose skin is a thin shell
+        # (mass = surface x density), modelled as a prolate half-ellipsoid. 0.55 is representative 
+        # of a typical elongated nose (l_nose / r_base ~ 2-3).
+        x_cg_nose = l_nose * 0.55  # [m]
         x_cg_mid = l_nose + l_mid / 2  # [m]
         x_cg_rear = (
             l_nose

--- a/src/fastuav/models/stability/static_longitudinal/center_of_gravity/components/cog_airframe.py
+++ b/src/fastuav/models/stability/static_longitudinal/center_of_gravity/components/cog_airframe.py
@@ -118,7 +118,6 @@ class CoG_fuselage(om.ExplicitComponent):
         self.add_input("data:weight:airframe:fuselage:mass:nose", val=np.nan, units="kg")
         self.add_input("data:weight:airframe:fuselage:mass:mid", val=np.nan, units="kg")
         self.add_input("data:weight:airframe:fuselage:mass:rear", val=np.nan, units="kg")
-        self.add_input("data:weight:airframe:fuselage:mass", val=np.nan, units="kg")
         self.add_output("data:stability:CoG:airframe:fuselage", units="m")
 
     def setup_partials(self):
@@ -129,19 +128,24 @@ class CoG_fuselage(om.ExplicitComponent):
         l_nose = inputs["data:geometry:fuselage:length:nose"]
         l_mid = inputs["data:geometry:fuselage:length:mid"]
         l_rear = inputs["data:geometry:fuselage:length:rear"]
-        d_fus_mid = inputs["data:geometry:fuselage:diameter:mid"]
-        d_fus_tip = inputs["data:geometry:fuselage:diameter:tip"]
+        r_fus_mid = inputs["data:geometry:fuselage:diameter:mid"] / 2
+        r_fus_tip = inputs["data:geometry:fuselage:diameter:tip"] / 2
         m_nose = inputs["data:weight:airframe:fuselage:mass:nose"]
         m_mid = inputs["data:weight:airframe:fuselage:mass:mid"]
         m_rear = inputs["data:weight:airframe:fuselage:mass:rear"]
-        m_fus = inputs["data:weight:airframe:fuselage:mass"]
 
-        x_cg_nose = l_nose / 2  # [m]
+        x_cg_nose = l_nose * (3 / 4)  # [m] centroid of a half-ellipsoid (nose)
         x_cg_mid = l_nose + l_mid / 2  # [m]
         x_cg_rear = (
-            l_nose + l_mid + l_rear / 3 * (d_fus_mid + 2 * d_fus_tip) / (d_fus_mid + d_fus_tip)
+            l_nose
+            + l_mid
+            + (l_rear / 4)
+            * (r_fus_mid**2 + 2 * r_fus_tip * r_fus_mid + 3 * r_fus_tip**2)
+            / (r_fus_mid**2 + r_fus_tip * r_fus_mid + r_fus_tip**2)
+        )  # [m] centroid of a truncated cone (rear)
+        x_cg_fus = (m_nose * x_cg_nose + m_mid * x_cg_mid + m_rear * x_cg_rear) / (
+            m_nose + m_mid + m_rear
         )  # [m]
-        x_cg_fus = (m_nose * x_cg_nose + m_mid * x_cg_mid + m_rear * x_cg_rear) / m_fus  # [m]
 
         outputs["data:stability:CoG:airframe:fuselage"] = x_cg_fus
 

--- a/src/fastuav/models/stability/static_longitudinal/center_of_gravity/components/cog_airframe.py
+++ b/src/fastuav/models/stability/static_longitudinal/center_of_gravity/components/cog_airframe.py
@@ -135,7 +135,7 @@ class CoG_fuselage(om.ExplicitComponent):
         m_rear = inputs["data:weight:airframe:fuselage:mass:rear"]
 
         # Nose CG, measured from the tip (x=0). The nose skin is a thin shell
-        # (mass = surface x density), modelled as a prolate half-ellipsoid. 0.55 is representative 
+        # (mass = surface x density), modelled as a prolate half-ellipsoid. 0.55 is representative
         # of a typical elongated nose (l_nose / r_base ~ 2-3).
         x_cg_nose = l_nose * 0.55  # [m]
         x_cg_mid = l_nose + l_mid / 2  # [m]

--- a/src/fastuav/models/stability/static_longitudinal/center_of_gravity/components/cog_load.py
+++ b/src/fastuav/models/stability/static_longitudinal/center_of_gravity/components/cog_load.py
@@ -1,0 +1,86 @@
+"""
+Module containing the center of gravity calculations for the payload and the non-modeled parts
+"""
+
+import numpy as np
+import openmdao.api as om
+
+from fastuav.constants import FW_PROPULSION, MR_PROPULSION
+
+
+class CoG_load_FW(om.ExplicitComponent):
+    """
+    Computes the center of gravity of the fixed wing payload and the non-modeled parts
+    """
+
+    def initialize(self):
+        self.options.declare("propulsion_id", default=FW_PROPULSION, values=[FW_PROPULSION])
+
+    def setup(self):
+        propulsion_id = self.options["propulsion_id"]
+        self.add_input("data:geometry:fuselage:length:nose", val=np.nan, units="m")
+        self.add_input("data:geometry:fuselage:length:mid", val=np.nan, units="m")
+        self.add_input("mission:sizing:payload:mass", val=np.nan, units="kg")
+        self.add_input("data:weight:misc:mass", val=np.nan, units="kg")
+        self.add_input(
+            "data:weight:propulsion:%s:wires:mass" % propulsion_id, val=np.nan, units="kg"
+        )
+        self.add_input("data:weight:propulsion:%s:esc:mass" % propulsion_id, val=np.nan, units="kg")
+        self.add_output("data:weight:load:%s" % propulsion_id, units="kg")
+        self.add_output("data:stability:CoG:load:%s" % propulsion_id, units="m")
+
+    def setup_partials(self):
+        self.declare_partials("*", "*", method="fd")
+
+    def compute(self, inputs, outputs):
+        propulsion_id = self.options["propulsion_id"]
+        lf_nose = inputs["data:geometry:fuselage:length:nose"]
+        lf_mid = inputs["data:geometry:fuselage:length:mid"]
+        m_payload = inputs["mission:sizing:payload:mass"]
+        m_misc = inputs["data:weight:misc:mass"]
+        m_wires = inputs["data:weight:propulsion:%s:wires:mass" % propulsion_id]
+        m_esc = inputs["data:weight:propulsion:%s:esc:mass" % propulsion_id]
+
+        m_load = m_wires + m_payload + m_misc + m_esc
+        x_cg_load = lf_nose + lf_mid / 2
+
+        outputs["data:weight:load:%s" % propulsion_id] = m_load
+        outputs["data:stability:CoG:load:%s" % propulsion_id] = x_cg_load
+
+
+class CoG_load_MR(om.ExplicitComponent):
+    """
+    Computes the center of gravity of the multirotor non-modeled parts
+    """
+
+    def initialize(self):
+        self.options.declare("propulsion_id", default=MR_PROPULSION, values=[MR_PROPULSION])
+
+    def setup(self):
+        propulsion_id = self.options["propulsion_id"]
+        self.add_input("data:geometry:fuselage:length:nose", val=np.nan, units="m")
+        self.add_input("data:geometry:fuselage:length:mid", val=np.nan, units="m")
+        self.add_input(
+            "data:weight:propulsion:%s:wires:mass" % propulsion_id, val=np.nan, units="kg"
+        )
+        self.add_input("data:weight:propulsion:%s:esc:mass" % propulsion_id, val=np.nan, units="kg")
+        self.add_input("mission:sizing:payload:mass", val=np.nan, units="kg")
+        self.add_input("data:weight:misc:mass", val=np.nan, units="kg")
+        self.add_output("data:weight:load:%s" % propulsion_id, units="kg")
+        self.add_output("data:stability:CoG:load:%s" % propulsion_id, units="m")
+
+    def setup_partials(self):
+        self.declare_partials("*", "*", method="fd")
+
+    def compute(self, inputs, outputs):
+        propulsion_id = self.options["propulsion_id"]
+        lf_nose = inputs["data:geometry:fuselage:length:nose"]
+        lf_mid = inputs["data:geometry:fuselage:length:mid"]
+        m_wires = inputs["data:weight:propulsion:%s:wires:mass" % propulsion_id]
+        m_esc = inputs["data:weight:propulsion:%s:esc:mass" % propulsion_id]
+
+        m_load = m_wires + 4 * m_esc
+        x_cg_load = lf_nose + lf_mid / 2
+
+        outputs["data:weight:load:%s" % propulsion_id] = m_load
+        outputs["data:stability:CoG:load:%s" % propulsion_id] = x_cg_load

--- a/src/fastuav/models/stability/static_longitudinal/center_of_gravity/components/cog_load.py
+++ b/src/fastuav/models/stability/static_longitudinal/center_of_gravity/components/cog_load.py
@@ -30,7 +30,31 @@ class CoG_load_FW(om.ExplicitComponent):
         self.add_output("data:stability:CoG:load:%s" % propulsion_id, units="m")
 
     def setup_partials(self):
-        self.declare_partials("*", "*", method="fd")
+        propulsion_id = self.options["propulsion_id"]
+
+        # CoG of the load is a linear function of the fuselage geometry
+        self.declare_partials(
+            "data:stability:CoG:load:%s" % propulsion_id,
+            "data:geometry:fuselage:length:nose",
+            val=1.0,
+        )
+        self.declare_partials(
+            "data:stability:CoG:load:%s" % propulsion_id,
+            "data:geometry:fuselage:length:mid",
+            val=0.5,
+        )
+
+        # Load mass is a plain sum of the contributing masses
+        self.declare_partials(
+            "data:weight:load:%s" % propulsion_id,
+            [
+                "data:weight:propulsion:%s:wires:mass" % propulsion_id,
+                "mission:sizing:payload:mass",
+                "data:weight:misc:mass",
+                "data:weight:propulsion:%s:esc:mass" % propulsion_id,
+            ],
+            val=1.0,
+        )
 
     def compute(self, inputs, outputs):
         propulsion_id = self.options["propulsion_id"]
@@ -70,7 +94,31 @@ class CoG_load_MR(om.ExplicitComponent):
         self.add_output("data:stability:CoG:load:%s" % propulsion_id, units="m")
 
     def setup_partials(self):
-        self.declare_partials("*", "*", method="fd")
+        propulsion_id = self.options["propulsion_id"]
+
+        # CoG of the load is a linear function of the fuselage geometry
+        self.declare_partials(
+            "data:stability:CoG:load:%s" % propulsion_id,
+            "data:geometry:fuselage:length:nose",
+            val=1.0,
+        )
+        self.declare_partials(
+            "data:stability:CoG:load:%s" % propulsion_id,
+            "data:geometry:fuselage:length:mid",
+            val=0.5,
+        )
+
+        # Load mass sums the wires and the four ESCs
+        self.declare_partials(
+            "data:weight:load:%s" % propulsion_id,
+            "data:weight:propulsion:%s:wires:mass" % propulsion_id,
+            val=1.0,
+        )
+        self.declare_partials(
+            "data:weight:load:%s" % propulsion_id,
+            "data:weight:propulsion:%s:esc:mass" % propulsion_id,
+            val=4.0,
+        )
 
     def compute(self, inputs, outputs):
         propulsion_id = self.options["propulsion_id"]

--- a/src/fastuav/models/stability/static_longitudinal/center_of_gravity/components/cog_propulsion.py
+++ b/src/fastuav/models/stability/static_longitudinal/center_of_gravity/components/cog_propulsion.py
@@ -21,24 +21,24 @@ class CoG_propulsion_FW(om.ExplicitComponent):
         propulsion_id = self.options["propulsion_id"]
         propulsion_conf = self.options["propulsion_conf"]
 
+        self.add_input(
+            "data:weight:propulsion:%s:gearbox:mass" % propulsion_id,
+            val=0.0,
+            units="kg",
+        )
         self.add_input("data:geometry:wing:root:LE:x", val=np.nan, units="m")
         self.add_input("data:geometry:wing:root:TE:x", val=np.nan, units="m")
-        self.add_input(
-            "data:propulsion:%s:motor:length:estimated" % propulsion_id,
-            val=np.nan,
-            units="m",
-        )
-        if propulsion_conf == "pusher":
-            self.add_input("data:geometry:fuselage:length", val=np.nan, units="m")
-        self.add_input(
-            "data:propulsion:%s:propeller:number" % propulsion_id,
-            val=np.nan,
-            units=None,
-        )
         self.add_input(
             "data:weight:propulsion:%s:propeller:mass" % propulsion_id,
             val=np.nan,
             units="kg",
+        )
+        if propulsion_conf == "pusher":
+            self.add_input("data:geometry:fuselage:length", val=np.nan, units="m")
+        self.add_input(
+            "data:propulsion:%s:motor:length:estimated" % propulsion_id,
+            val=np.nan,
+            units="m",
         )
         self.add_input(
             "data:weight:propulsion:%s:motor:mass" % propulsion_id,
@@ -62,11 +62,11 @@ class CoG_propulsion_FW(om.ExplicitComponent):
         propulsion_conf = self.options["propulsion_conf"]
         x_root_LE_w = inputs["data:geometry:wing:root:LE:x"]
         x_root_TE_w = inputs["data:geometry:wing:root:TE:x"]
-        l_mot = inputs["data:propulsion:%s:motor:length:estimated" % propulsion_id]
+        m_gearbox = inputs["data:weight:propulsion:%s:gearbox:mass" % propulsion_id]
         m_pro = inputs["data:weight:propulsion:%s:propeller:mass" % propulsion_id]
+        l_mot = inputs["data:propulsion:%s:motor:length:estimated" % propulsion_id]
         m_mot = inputs["data:weight:propulsion:%s:motor:mass" % propulsion_id]
         m_bat = inputs["data:weight:propulsion:%s:battery:mass" % propulsion_id]
-        N_pro = inputs["data:propulsion:%s:propeller:number" % propulsion_id]
 
         if propulsion_conf == "pusher":
             l_fus = inputs["data:geometry:fuselage:length"]
@@ -80,9 +80,9 @@ class CoG_propulsion_FW(om.ExplicitComponent):
             x_root_LE_w + x_root_TE_w
         ) / 2  # [m] wing-integrated or centered at wing position
 
-        m_propulsion = N_pro * m_pro + N_pro * m_mot + m_bat
+        m_propulsion = m_pro + m_mot + m_bat + m_gearbox
         x_cg_propulsion = (
-            N_pro * x_cg_pro * m_pro + N_pro * x_cg_mot * m_mot + x_cg_bat * m_bat
+            x_cg_pro * m_pro + x_cg_mot * (m_mot + m_gearbox) + x_cg_bat * m_bat
         ) / m_propulsion
 
         outputs["data:weight:propulsion:%s" % propulsion_id] = m_propulsion
@@ -142,16 +142,13 @@ class CoG_propulsion_MR(om.ExplicitComponent):
         m_bat = inputs["data:weight:propulsion:%s:battery:mass" % propulsion_id]
         N_pro = inputs["data:propulsion:%s:propeller:number" % propulsion_id]
 
-        x_cg_pro = x_cg_mot = (
-            x_pro_front + x_pro_rear
-        ) / 2  # [m] average position of the propellers / motors
         x_cg_bat = (
             x_root_LE_w + x_root_TE_w
         ) / 2  # [m] wing-integrated or centered at wing position
 
         m_propulsion = N_pro * m_pro + N_pro * m_mot + m_bat
         x_cg_propulsion = (
-            N_pro * x_cg_pro * m_pro + N_pro * x_cg_mot * m_mot + x_cg_bat * m_bat
+            2 * x_pro_front * (m_pro + m_mot) + 2 * x_pro_rear * (m_pro + m_mot) + x_cg_bat * m_bat
         ) / m_propulsion
 
         outputs["data:weight:propulsion:%s" % propulsion_id] = m_propulsion

--- a/src/fastuav/models/stability/static_longitudinal/static_margin.py
+++ b/src/fastuav/models/stability/static_longitudinal/static_margin.py
@@ -16,7 +16,7 @@ class StaticMargin(om.ExplicitComponent):
 
     def setup(self):
         self.add_input("data:stability:neutral_point", val=np.nan, units="m")
-        self.add_input("data:stability:CoG", val=np.nan, units="m")
+        self.add_input("data:stability:CoG:x", val=np.nan, units="m")
         self.add_input("data:geometry:wing:MAC:length", val=np.nan, units="m")
         self.add_output("data:stability:static_margin", units=None)
 
@@ -25,7 +25,7 @@ class StaticMargin(om.ExplicitComponent):
 
     def compute(self, inputs, outputs):
         x_np = inputs["data:stability:neutral_point"]
-        x_cg = inputs["data:stability:CoG"]
+        x_cg = inputs["data:stability:CoG:x"]
         c_MAC = inputs["data:geometry:wing:MAC:length"]
 
         SM = (x_np - x_cg) / c_MAC  # static margin [-]
@@ -34,11 +34,11 @@ class StaticMargin(om.ExplicitComponent):
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
         x_np = inputs["data:stability:neutral_point"]
-        x_cg = inputs["data:stability:CoG"]
+        x_cg = inputs["data:stability:CoG:x"]
         c_MAC = inputs["data:geometry:wing:MAC:length"]
 
         partials["data:stability:static_margin", "data:stability:neutral_point"] = 1 / c_MAC
-        partials["data:stability:static_margin", "data:stability:CoG"] = -1 / c_MAC
+        partials["data:stability:static_margin", "data:stability:CoG:x"] = -1 / c_MAC
         partials["data:stability:static_margin", "data:geometry:wing:MAC:length"] = (
             -(x_np - x_cg) / c_MAC**2
         )
@@ -51,7 +51,7 @@ class StaticMarginConstraints(om.ExplicitComponent):
 
     def setup(self):
         self.add_input("data:stability:static_margin", val=np.nan, units=None)
-        self.add_input("data:stability:static_margin:requirement:min", val=0.10, units=None)
+        self.add_input("data:stability:static_margin:requirement:min", val=0.05, units=None)
         self.add_input("data:stability:static_margin:requirement:max", val=0.40, units=None)
         self.add_output("optimization:constraints:stability:static_margin:min", units=None)
         self.add_output("optimization:constraints:stability:static_margin:max", units=None)

--- a/src/fastuav/models/stability/static_longitudinal/static_margin.py
+++ b/src/fastuav/models/stability/static_longitudinal/static_margin.py
@@ -71,9 +71,11 @@ class StaticMarginConstraints(om.ExplicitComponent):
         outputs["optimization:constraints:stability:static_margin:max"] = SM_con_max
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
+        SM = inputs["data:stability:static_margin"]
         SM_min = inputs["data:stability:static_margin:requirement:min"]
         SM_max = inputs["data:stability:static_margin:requirement:max"]
 
+        # SM_con_min = (SM - SM_min) / SM_min = SM / SM_min - 1
         partials[
             "optimization:constraints:stability:static_margin:min",
             "data:stability:static_margin",
@@ -81,7 +83,8 @@ class StaticMarginConstraints(om.ExplicitComponent):
         partials[
             "optimization:constraints:stability:static_margin:min",
             "data:stability:static_margin:requirement:min",
-        ] = -1 / SM_min**2 if SM_min != 0 else -1.0
+        ] = -SM / SM_min**2 if SM_min != 0 else -1.0
+        # SM_con_max = (SM_max - SM) / SM_max = 1 - SM / SM_max
         partials[
             "optimization:constraints:stability:static_margin:max",
             "data:stability:static_margin",
@@ -89,4 +92,4 @@ class StaticMarginConstraints(om.ExplicitComponent):
         partials[
             "optimization:constraints:stability:static_margin:max",
             "data:stability:static_margin:requirement:max",
-        ] = 1 / SM_max**2 if SM_max != 0 else 1.0
+        ] = SM / SM_max**2 if SM_max != 0 else 1.0

--- a/src/fastuav/models/variable_descriptions.txt
+++ b/src/fastuav/models/variable_descriptions.txt
@@ -554,7 +554,9 @@ data:geometry:fuselage:diameter:k || Tail cone diameter ratio (mid to tip)
 data:geometry:fuselage:diameter:mid || Diameter of fuselage mid-section
 data:geometry:fuselage:diameter:tip || Tip diameter of fuselage
 optimization:constraints:geometry:fuselage:volume || Constraint on fuselage volume to house batteries and payload
+data:geometry:fuselage:volume:nose || Volume of fuselage nose-section
 data:geometry:fuselage:volume:mid || Volume of fuselage mid-section
+data:geometry:fuselage:volume:rear || Volume of fuselage rear-section
 optimization:variables:geometry:wing:AR || Aspect ratio of wing
 optimization:variables:geometry:wing:lambda || Taper ratio of wing
 data:geometry:wing:loading || Wing loading
@@ -646,6 +648,13 @@ data:weight:airframe:wing:spar:mass || Spars mass
 
 # Stability
 data:stability:CoG || Center of gravity (longitudinal)
+data:stability:CoG:x || Center of gravity (longitudinal, x-axis)
+data:stability:CoG:y || Center of gravity (lateral, y-axis)
+data:stability:CoG:z || Center of gravity (vertical, z-axis)
+data:stability:CoG:load:fixedwing || Center of gravity of fixed-wing payload and non-modeled parts
+data:stability:CoG:load:multirotor || Center of gravity of multirotor payload and non-modeled parts
+data:weight:load:fixedwing || Mass of fixed-wing payload and non-modeled parts
+data:weight:load:multirotor || Mass of multirotor payload and non-modeled parts
 data:stability:CoG:airframe || Center of gravity of airframe
 data:stability:CoG:airframe:fuselage || Center of gravity of fuselage
 data:stability:CoG:airframe:wing || Center of gravity of wing

--- a/src/fastuav/notebooks/data/configurations/fixedwing_mdo.yaml
+++ b/src/fastuav/notebooks/data/configurations/fixedwing_mdo.yaml
@@ -12,6 +12,10 @@ driver: om.ScipyOptimizeDriver(tol=1e-9, optimizer='SLSQP')
 
 # Definition of OpenMDAO model
 model:
+    # Converge the discipline coupling at every evaluation so the design point is
+    # self-consistent and the (analytic) total derivatives are exact for the optimizer.
+    nonlinear_solver: om.NonlinearBlockGS(maxiter=200, atol=1.0e-9, rtol=1.0e-9, iprint=0)
+    linear_solver: om.DirectSolver()
     scenarios:
         id: fastuav.scenarios.fixedwing
     propulsion:

--- a/src/fastuav/notebooks/data/configurations/hybrid_mdo.yaml
+++ b/src/fastuav/notebooks/data/configurations/hybrid_mdo.yaml
@@ -12,6 +12,10 @@ driver: om.ScipyOptimizeDriver(tol=1e-9, optimizer='SLSQP')
 
 # Definition of OpenMDAO model
 model:
+    # Converge the discipline coupling at every evaluation so the design point is
+    # self-consistent and the (analytic) total derivatives are exact for the optimizer.
+    nonlinear_solver: om.NonlinearBlockGS(maxiter=300, atol=1.0e-9, rtol=1.0e-9, iprint=0)
+    linear_solver: om.DirectSolver()
     scenarios:
         id: fastuav.scenarios.hybrid
     propulsion:

--- a/src/fastuav/notebooks/data/configurations/multirotor_mdo.yaml
+++ b/src/fastuav/notebooks/data/configurations/multirotor_mdo.yaml
@@ -9,6 +9,10 @@ driver: om.ScipyOptimizeDriver(tol=1e-9, optimizer='SLSQP')
 
 # Definition of OpenMDAO model
 model:
+    # Converge the discipline coupling at every evaluation so the design point is
+    # self-consistent and the (analytic) total derivatives are exact for the optimizer.
+    nonlinear_solver: om.NonlinearBlockGS(maxiter=200, atol=1.0e-9, rtol=1.0e-9, iprint=0)
+    linear_solver: om.DirectSolver()
     scenarios:
         id: fastuav.scenarios.multirotor
     propulsion:

--- a/src/fastuav/tests/test_convergence_specs.py
+++ b/src/fastuav/tests/test_convergence_specs.py
@@ -1,0 +1,165 @@
+"""
+Convergence / model-integrity tests across several specifications (cahiers des charges).
+
+The goal of this module is to exercise the FAST-UAV models over a range of design
+requirements and architectures (multirotor, fixed-wing, hybrid VTOL) in order to
+surface model and formulation errors (NaN/inf, non-physical values, non-convergence
+of the design optimization).
+
+Two complementary checks are performed:
+
+* ``test_model_integrity`` -- a single evaluation of the whole model for each
+  architecture and each specification. It catches formulation errors that show up
+  immediately (NaN/inf outputs, non-physical MTOW).
+
+* ``test_mdo_convergence`` -- the full multidisciplinary design optimization is run
+  with the standard ``oad.optimize_problem`` (SLSQP) for each architecture and each
+  specification, and the design must converge to a feasible optimum (all constraints
+  satisfied to a tight tolerance).
+
+  Convergence relies on the OpenMDAO solver stack declared in the configuration files
+  (``nonlinear_solver: om.NonlinearBlockGS`` + ``linear_solver: om.DirectSolver``):
+  the disciplines are coupled (the sizing depends on the MTOW guess that depends on the
+  sizing), so every evaluation must be converged for the function -- and therefore the
+  analytic total derivatives -- to be consistent. Without the solver each evaluation is
+  a single pass that lags by one iteration, the gradients are inconsistent and SLSQP
+  stalls ("positive directional derivative").
+"""
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import fastoad.api as oad
+import numpy as np
+import pytest
+
+PKG_ROOT = Path(__file__).resolve().parents[1]  # .../src/fastuav
+CONF_DIR = PKG_ROOT / "configurations"
+SRC_DIR = PKG_ROOT / "notebooks" / "data" / "source_files"
+
+# Architecture -> (configuration file, reference source file)
+ARCHITECTURES = {
+    "multirotor": (CONF_DIR / "multirotor_mdo.yaml", SRC_DIR / "problem_inputs_DJI_M600.xml"),
+    "fixedwing": (CONF_DIR / "fixedwing_mdo.yaml", SRC_DIR / "problem_inputs_FW.xml"),
+    "hybrid": (CONF_DIR / "hybrid_mdo.yaml", SRC_DIR / "problem_inputs_hybrid.xml"),
+}
+
+# Cahiers des charges: a small set of representative specifications.
+# Each entry is {variable_name: (value, units)}.
+SPECS = {
+    "nominal": {},
+    "light_payload": {"mission:sizing:payload:mass": (2.0, "kg")},
+    "heavy_payload": {"mission:sizing:payload:mass": (5.0, "kg")},
+}
+
+CONSTRAINT_TOL = 1e-4  # max allowed constraint violation at the converged optimum
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _make_configuration(architecture, overrides, workdir):
+    """Write an isolated configuration + input file in ``workdir``.
+
+    A copy of the configuration is written with absolute input/output and mission
+    paths so the test never touches the repository working directory. ``overrides``
+    (the cahier des charges) are applied to the generated input file.
+    Returns the path to the temporary configuration file.
+    """
+    import yaml
+
+    conf_path, src_path = ARCHITECTURES[architecture]
+    conf = yaml.safe_load(conf_path.read_text())
+
+    conf["input_file"] = os.path.join(workdir, "inputs.xml")
+    conf["output_file"] = os.path.join(workdir, "outputs.xml")
+    mission_rel = conf["model"]["performance"]["missions"]["file_path"]
+    conf["model"]["performance"]["missions"]["file_path"] = str(
+        (conf_path.parent / mission_rel).resolve()
+    )
+
+    new_conf = os.path.join(workdir, "configuration.yaml")
+    with open(new_conf, "w") as f:
+        yaml.safe_dump(conf, f)
+
+    oad.generate_inputs(new_conf, str(src_path), overwrite=True)
+
+    if overrides:
+        data = oad.DataFile(conf["input_file"])
+        for name, (value, units) in overrides.items():
+            data[name].value = value
+            if units is not None:
+                data[name].units = units
+        data.save()
+
+    return new_conf
+
+
+def _max_constraint_violation(problem):
+    """Largest violation over all optimization constraints (0 if all satisfied)."""
+    violation = 0.0
+    worst = ""
+    for name, meta in problem.driver._cons.items():
+        value = float(problem.get_val(name).ravel()[0])
+        lower, upper = meta.get("lower"), meta.get("upper")
+        local = 0.0
+        if lower is not None and np.isfinite(lower):
+            local = max(local, lower - value)
+        if upper is not None and np.isfinite(upper):
+            local = max(local, value - upper)
+        if local > violation:
+            violation, worst = local, name
+    return violation, worst
+
+
+def _non_finite_outputs(problem):
+    """Return the list of model output names holding a NaN or inf value."""
+    bad = []
+    for name, meta in problem.model.list_outputs(out_stream=None, val=True):
+        if np.any(~np.isfinite(np.atleast_1d(meta["val"]))):
+            bad.append(name)
+    return bad
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("architecture", list(ARCHITECTURES))
+@pytest.mark.parametrize("spec_name", list(SPECS))
+def test_model_integrity(architecture, spec_name):
+    """A single model evaluation must not produce NaN/inf or non-physical mass."""
+    workdir = tempfile.mkdtemp(prefix=f"fastuav_{architecture}_{spec_name}_")
+    try:
+        conf = _make_configuration(architecture, SPECS[spec_name], workdir)
+        problem = oad.evaluate_problem(conf, overwrite=True)
+
+        bad = _non_finite_outputs(problem)
+        assert not bad, f"{architecture}/{spec_name}: non-finite outputs: {bad[:15]}"
+
+        mtow = float(problem.get_val("data:weight:mtow", units="kg")[0])
+        assert np.isfinite(mtow) and mtow > 0.0, f"unphysical MTOW: {mtow}"
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+@pytest.mark.parametrize("architecture", list(ARCHITECTURES))
+@pytest.mark.parametrize("spec_name", list(SPECS))
+def test_mdo_convergence(architecture, spec_name):
+    """The full design optimization must converge to a feasible optimum."""
+    workdir = tempfile.mkdtemp(prefix=f"fastuav_mdo_{architecture}_{spec_name}_")
+    try:
+        conf = _make_configuration(architecture, SPECS[spec_name], workdir)
+        problem = oad.optimize_problem(conf, overwrite=True)
+
+        violation, worst = _max_constraint_violation(problem)
+        assert violation < CONSTRAINT_TOL, (
+            f"{architecture}/{spec_name}: optimization not feasible "
+            f"(max violation {violation:.2e} on {worst})"
+        )
+
+        mtow = float(problem.get_val("data:weight:mtow", units="kg")[0])
+        assert np.isfinite(mtow) and 0.0 < mtow < 1.0e4, f"unphysical MTOW: {mtow}"
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)


### PR DESCRIPTION
## Summary

Brings over a batch of model corrections and, most importantly, makes the full
design optimization converge robustly for the multirotor, fixed-wing and hybrid
VTOL architectures.

## Convergence fix

The FAST-UAV model is discipline-coupled (the sizing depends on the MTOW guess,
which depends on the sizing), but the MDO configurations declared no solver, so
each evaluation was a single feed-forward pass that lagged by one iteration. As a
result the function was inconsistent/noisy, the analytic total derivatives were
wrong, and SLSQP was often stalling ("positive directional derivative").

Adding an OpenMDAO solver stack to the coupled model fixes it (despite using the NVH):

    nonlinear_solver: om.NonlinearBlockGS(maxiter=200, atol=1.0e-9, rtol=1.0e-9, iprint=0)
    linear_solver: om.DirectSolver()

With this, `oad.optimize_problem` now converges to a feasible optimum.

## Derivative / robustness corrections (found with `check_partials` / `check_totals`)

- `MotorEfficiency`: the partial w.r.t. voltage was declared twice (with the
  current formula) and the partial w.r.t. current was missing — corrected.
- `StaticMarginConstraints`: the derivative w.r.t. the requirement was
  `-1/SM_min**2` instead of `-SM/SM_min**2` (idem for the max side) — corrected.
- Propeller efficiency: guard a stopped rotor (VTOL rotors in cruise, `W_pro -> 0`)
  that produced a NaN; tighten the induced-velocity `fsolve` tolerance.

## Model corrections

- Fuselage geometry: add nose and rear volume outputs.
- Center of gravity: improved fuselage CoG formulas (nose/rear centroids, mass
  weighting), a new load-CoG contribution (payload + non-modeled parts), and the
  longitudinal CoG output renamed `data:stability:CoG` -> `data:stability:CoG:x`
  (with `:y`/`:z`); downstream `StaticMargin` updated accordingly.
- Aerodynamics: require an explicit `CD0` guess input.
- Variable descriptions added for the new outputs.

## Tests

New `src/fastuav/tests/test_convergence_specs.py`:
- `test_model_integrity` — single evaluation must not produce NaN/inf or a
  non-physical MTOW;
- `test_mdo_convergence` — the full optimization must reach a feasible optimum;

over 3 architectures x 3 specifications (payload variants).